### PR TITLE
Files protocol extension

### DIFF
--- a/vscode-client/.gitignore
+++ b/vscode-client/.gitignore
@@ -2,3 +2,4 @@ out
 server
 node_modules
 .vscode-dev
+typings/

--- a/vscode-client/.vscode/settings.json
+++ b/vscode-client/.vscode/settings.json
@@ -6,5 +6,5 @@
 	"search.exclude": {
 		"out": true // set this to false to include "out" folder in search results
 	},
-	"typescript.tsdk": "/dev/null"
+	"typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/vscode-client/.vscode/tasks.json
+++ b/vscode-client/.vscode/tasks.json
@@ -1,30 +1,19 @@
-// Available variables which can be used inside of strings.
-// ${workspaceRoot}: the root folder of the team
-// ${file}: the current opened file
-// ${fileBasename}: the current opened file's basename
-// ${fileDirname}: the current opened file's dirname
-// ${fileExtname}: the current opened file's extension
-// ${cwd}: the current working directory of the spawned process
-
-// A task runner that calls a custom npm script that compiles the extension.
 {
 	"version": "0.1.0",
-
-	// we want to run npm
 	"command": "npm",
-
-	// the command is a shell script
+	"args": ["run", "--silent"],
 	"isShellCommand": true,
-
-	// show the output window only if unrecognized errors occur.
 	"showOutput": "silent",
-
-	// we run the custom script "compile" as defined in package.json
-	"args": ["run", "compile", "--loglevel", "silent"],
-
-	// The tsc compiler is started in watching mode
-	"isWatching": true,
-
-	// use the standard tsc in watch mode problem matcher to find compile problems in the output.
-	"problemMatcher": "$tsc-watch"
+	"tasks": [
+		{
+			"taskName": "compile",
+			"isBuildCommand": true,
+			"problemMatcher": "$tsc"
+		},
+		{
+			"taskName": "watch",
+			"isWatching": true,
+			"problemMatcher": "$tsc-watch"
+		}
+	]
 }

--- a/vscode-client/package.json
+++ b/vscode-client/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "vscode": "^1.0.3",
-    "vscode-languageclient": "^2.6.2"
+    "vscode-languageclient": "^2.6.2",
+    "vscode-languageserver-types": "^1.0.4"
   }
 }

--- a/vscode-client/package.json
+++ b/vscode-client/package.json
@@ -1,31 +1,32 @@
 {
-	"name": "vscode-client",
-	"description": "VSCode extension for running multiple language servers",
-	"author": "Sourcegraph",
-	"license": "MIT",
-	"version": "0.0.1",
-	"publisher": "sqs",
-	"engines": {
-		"vscode": "^1.4.0"
-	},
-	"categories": [
-		"Other"
-	],
-	"activationEvents": [
-		"*"
-	],
-	"main": "./out/src/extension",
-	"scripts": {
-		"vscode:prepublish": "node ./node_modules/vscode/bin/compile",
-		"compile": "node ./node_modules/vscode/bin/compile -watch -p ./",
-		"postinstall": "node ./node_modules/vscode/bin/install",
-		"vscode": "npm run vscode:prepublish && VSCODE=$(which code-insiders || which code || echo echo ERROR: neither the code nor code-insiders vscode executable is installed); USER=dummy-dont-share-vscode-instance $VSCODE --user-data-dir=$PWD/.vscode-dev/user-data --extensionHomePath=$PWD/.vscode-dev/extensions --extensionDevelopmentPath=$PWD $*"
-	},
-	"devDependencies": {
-		"typescript": "^1.8.9",
-		"vscode": "^0.11.0"
-	},
-	"dependencies": {
-		"vscode-languageclient": "^2.4.2-next.12"
-	}
+  "name": "vscode-client",
+  "description": "VSCode extension for running multiple language servers",
+  "author": "Sourcegraph",
+  "license": "MIT",
+  "version": "0.0.1",
+  "publisher": "sqs",
+  "engines": {
+    "vscode": "^1.7.1"
+  },
+  "categories": [
+    "Other"
+  ],
+  "activationEvents": [
+    "*"
+  ],
+  "main": "./out/src/extension",
+  "scripts": {
+    "vscode:prepublish": "npm run compile",
+    "compile": "tsc -p ./",
+    "watch": "tsc -w -p ./",
+    "postinstall": "node ./node_modules/vscode/bin/install",
+    "vscode": "npm run vscode:prepublish && VSCODE=$(which code-insiders || which code || echo echo ERROR: neither the code nor code-insiders vscode executable is installed); USER=dummy-dont-share-vscode-instance $VSCODE --user-data-dir=$PWD/.vscode-dev/user-data --extensionHomePath=$PWD/.vscode-dev/extensions --extensionDevelopmentPath=$PWD $*"
+  },
+  "devDependencies": {
+    "typescript": "^2.0.9"
+  },
+  "dependencies": {
+    "vscode": "^1.0.3",
+    "vscode-languageclient": "^2.6.2"
+  }
 }

--- a/vscode-client/src/extension.ts
+++ b/vscode-client/src/extension.ts
@@ -8,15 +8,22 @@ import * as net from 'net';
 
 import { workspace, Disposable, ExtensionContext } from 'vscode';
 import { LanguageClient, LanguageClientOptions, SettingMonitor, ServerOptions, ErrorAction, ErrorHandler, CloseAction, TransportKind } from 'vscode-languageclient';
+import { TextDocumentIdentifier } from 'vscode-languageserver-types';
+import { FilesRequest, ContentRequest } from './protocol-extension-files';
+import * as vscode from 'vscode';
 
 function startLangServer(command: string, documentSelector: string | string[]): Disposable {
-	const serverOptions: ServerOptions = {
-		command: command,
-	};
-	const clientOptions: LanguageClientOptions = {
-		documentSelector: documentSelector,
-	}
-	return new LanguageClient(command, serverOptions, clientOptions).start();
+	const serverOptions: ServerOptions = { command };
+	const clientOptions: LanguageClientOptions = { documentSelector	};
+	const ls = new LanguageClient(command, serverOptions, clientOptions);
+
+	// How to send extended ClientCapabilities?
+
+	// Files extensions
+	ls.onRequest(FilesRequest.type, FilesRequest.handler);
+	ls.onRequest(ContentRequest.type, ContentRequest.handler);
+
+	return ls.start();
 }
 
 function startLangServerTCP(addr: number, documentSelector: string | string[]): Disposable {

--- a/vscode-client/src/protocol-extension-files.ts
+++ b/vscode-client/src/protocol-extension-files.ts
@@ -1,0 +1,90 @@
+
+/**
+ * Files extensions to LSP
+ *
+ * The files extension to the Language Server Protocol (LSP) allows a language
+ * server to operate without sharing a physical file system with the client.
+ * Instead of consulting its local disk, the language server can query the
+ * client for a list of all files and for the contents of specific files.
+ *
+ * https://github.com/sourcegraph/language-server-protocol/blob/master/extension-files.md
+ */
+
+/** */
+import { RequestType, RequestHandler } from 'vscode-jsonrpc';
+import { TextDocumentIdentifier, TextDocumentItem } from 'vscode-languageserver-types';
+import * as vscode from 'vscode';
+
+export interface FilesExtensionClientCapabilities {
+  /**
+   * The client provides support for workspace/xfiles.
+   */
+  xfilesProvider?: boolean;
+  /**
+   * The client provides support for textDocument/xcontent.
+   */
+  xcontentProvider?: boolean;
+}
+
+// workspace/xfiles
+
+export interface ContentParams {
+  /**
+   * The text document to receive the content for.
+   */
+  textDocument: TextDocumentIdentifier;
+}
+
+/**
+ * The content request is sent from the server to the client to request the
+ * current content of any text document. This allows language servers to operate
+ * without accessing the file system directly.
+ */
+export namespace ContentRequest {
+
+  export const type: RequestType<ContentParams, TextDocumentItem, void> = {
+    method: 'textDocument/xcontent'
+  };
+
+  export const handler: RequestHandler<ContentParams, TextDocumentItem, void> =
+    async (params: ContentParams, token: vscode.CancellationToken): Promise<TextDocumentItem> => {
+      // This is not nice because it will open the text document and emit didOpenTextDocument events,
+      // which we don't want. I couldn't find another way to get the text document content from VS Code though
+      const document = await vscode.workspace.openTextDocument(vscode.Uri.parse(params.textDocument.uri));
+      return {
+        uri: document.uri.toString(),
+        languageId: document.languageId,
+        version: document.version,
+        text: document.getText()
+      };
+    }
+}
+
+// textDocument/xfiles
+
+export interface FilesParams {
+  /**
+   * The URI of a directory to search.
+   * Can be relative to the rootPath.
+   * If not given, defaults to rootPath.
+   */
+  base?: string;
+}
+
+/**
+ * The files request is sent from the server to the client to request a list of
+ * all files in the workspace or inside the directory of the base parameter, if
+ * given.
+ */
+export namespace FilesRequest {
+
+  export const type: RequestType<FilesParams, TextDocumentIdentifier[], void> = {
+    method: 'workspace/xfiles'
+  };
+  
+  export const handler: RequestHandler<FilesParams, TextDocumentIdentifier[], void> =
+    async (params: FilesParams, token: vscode.CancellationToken): Promise<TextDocumentIdentifier[]> => {
+      const uris = await vscode.workspace.findFiles('**', '', Infinity, token);
+      return uris.map(uri => ({ uri: uri.toString() }));
+    }
+}

--- a/vscode-client/tsconfig.json
+++ b/vscode-client/tsconfig.json
@@ -1,14 +1,21 @@
 {
 	"compilerOptions": {
-		"target": "ES5",
+		"target": "ES6",
 		"module": "commonjs",
 		"moduleResolution": "node",
 		"outDir": "out",
-		"noLib": true,
-		"sourceMap": true
+		"sourceMap": true,
+		"noImplicitAny": true,
+		"strictNullChecks": true,
+		"noImplicitThis": true,
+		"noImplicitReturns": true,
+		"typeRoots": [
+			"typings/globals",
+			"typings/modules"
+		]
 	},
 	"exclude": [
 		"node_modules",
-		"server"
+		"out"
 	]
 }

--- a/vscode-client/typings.json
+++ b/vscode-client/typings.json
@@ -1,0 +1,7 @@
+{
+  "name": "vscode-client",
+  "dependencies": {},
+  "globalDependencies": {
+    "node": "registry:env/node#6.0.0+20161105011511"
+  }
+}

--- a/vscode-client/typings/node.d.ts
+++ b/vscode-client/typings/node.d.ts
@@ -1,1 +1,0 @@
-/// <reference path="../node_modules/vscode/typings/node.d.ts" />

--- a/vscode-client/typings/vscode-typings.d.ts
+++ b/vscode-client/typings/vscode-typings.d.ts
@@ -1,1 +1,0 @@
-/// <reference path="../node_modules/vscode/typings/index.d.ts" />


### PR DESCRIPTION
Adds support for the [files protocol extension](https://github.com/sourcegraph/language-server-protocol/blob/master/extension-files.md)

Limitations:
 - I could not find a way to send extended `ClientCapabilities`
 - I could not find a way to get the content of a text document without opening it (and emitting `didOpenTextDocument` events)

Also updates VS Code and TypeScript dependencies.